### PR TITLE
Implement Bugsnag.leaveBreadcrumb

### DIFF
--- a/bugsnag-kmp/src/androidMain/kotlin/com/bugsnag/kmp/BreadcrumbType.kt
+++ b/bugsnag-kmp/src/androidMain/kotlin/com/bugsnag/kmp/BreadcrumbType.kt
@@ -1,0 +1,14 @@
+package com.bugsnag.kmp
+
+import com.bugsnag.android.BreadcrumbType as PlatformBreadcrumbType
+
+internal fun BreadcrumbType.toPlatformType(): PlatformBreadcrumbType = when (this) {
+    BreadcrumbType.ERROR -> PlatformBreadcrumbType.ERROR
+    BreadcrumbType.LOG -> PlatformBreadcrumbType.LOG
+    BreadcrumbType.MANUAL -> PlatformBreadcrumbType.MANUAL
+    BreadcrumbType.NAVIGATION -> PlatformBreadcrumbType.NAVIGATION
+    BreadcrumbType.PROCESS -> PlatformBreadcrumbType.PROCESS
+    BreadcrumbType.REQUEST -> PlatformBreadcrumbType.REQUEST
+    BreadcrumbType.STATE -> PlatformBreadcrumbType.STATE
+    BreadcrumbType.USER -> PlatformBreadcrumbType.USER
+}

--- a/bugsnag-kmp/src/androidMain/kotlin/com/bugsnag/kmp/Bugsnag.kt
+++ b/bugsnag-kmp/src/androidMain/kotlin/com/bugsnag/kmp/Bugsnag.kt
@@ -9,6 +9,14 @@ public actual object Bugsnag {
 
     public actual fun isStarted(): Boolean = PlatformBugsnag.isStarted()
 
+    public actual fun leaveBreadcrumb(
+        message: String,
+        metadata: Map<String, Any>?,
+        type: BreadcrumbType,
+    ) {
+        PlatformBugsnag.leaveBreadcrumb(message, metadata.orEmpty(), type.toPlatformType())
+    }
+
     public actual fun addMetadata(section: String, key: String, value: Any?) {
         PlatformBugsnag.addMetadata(section, key, value)
     }

--- a/bugsnag-kmp/src/appleMain/kotlin/com/bugsnag/kmp/BreadcrumbType.kt
+++ b/bugsnag-kmp/src/appleMain/kotlin/com/bugsnag/kmp/BreadcrumbType.kt
@@ -1,0 +1,16 @@
+package com.bugsnag.kmp
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import com.bugsnag.cocoa.BSGBreadcrumbType as PlatformBreadcrumbType
+
+@OptIn(ExperimentalForeignApi::class)
+internal fun BreadcrumbType.toPlatformType(): PlatformBreadcrumbType = when (this) {
+    BreadcrumbType.ERROR -> PlatformBreadcrumbType.BSGBreadcrumbTypeError
+    BreadcrumbType.LOG -> PlatformBreadcrumbType.BSGBreadcrumbTypeLog
+    BreadcrumbType.MANUAL -> PlatformBreadcrumbType.BSGBreadcrumbTypeManual
+    BreadcrumbType.NAVIGATION -> PlatformBreadcrumbType.BSGBreadcrumbTypeNavigation
+    BreadcrumbType.PROCESS -> PlatformBreadcrumbType.BSGBreadcrumbTypeProcess
+    BreadcrumbType.REQUEST -> PlatformBreadcrumbType.BSGBreadcrumbTypeRequest
+    BreadcrumbType.STATE -> PlatformBreadcrumbType.BSGBreadcrumbTypeState
+    BreadcrumbType.USER -> PlatformBreadcrumbType.BSGBreadcrumbTypeUser
+}

--- a/bugsnag-kmp/src/appleMain/kotlin/com/bugsnag/kmp/Bugsnag.kt
+++ b/bugsnag-kmp/src/appleMain/kotlin/com/bugsnag/kmp/Bugsnag.kt
@@ -25,6 +25,16 @@ public actual object Bugsnag {
         PlatformBugsnag.addMetadata(data as Map<Any?, *>, section)
     }
 
+    public actual fun leaveBreadcrumb(
+        message: String,
+        metadata: Map<String, Any>?,
+        type: BreadcrumbType,
+    ) {
+        @Suppress("UNCHECKED_CAST")
+        val metadataMap = metadata?.let { it as Map<Any?, *> }
+        PlatformBugsnag.leaveBreadcrumbWithMessage(message, metadataMap, type.toPlatformType())
+    }
+
     public actual fun startSession() {
         PlatformBugsnag.startSession()
     }

--- a/bugsnag-kmp/src/commonMain/kotlin/com/bugsnag/kmp/BreadcrumbType.kt
+++ b/bugsnag-kmp/src/commonMain/kotlin/com/bugsnag/kmp/BreadcrumbType.kt
@@ -1,0 +1,12 @@
+package com.bugsnag.kmp
+
+public enum class BreadcrumbType {
+    ERROR,
+    LOG,
+    MANUAL,
+    NAVIGATION,
+    PROCESS,
+    REQUEST,
+    STATE,
+    USER,
+}

--- a/bugsnag-kmp/src/commonMain/kotlin/com/bugsnag/kmp/Bugsnag.kt
+++ b/bugsnag-kmp/src/commonMain/kotlin/com/bugsnag/kmp/Bugsnag.kt
@@ -8,6 +8,12 @@ public expect object Bugsnag {
     public fun startSession()
     public fun pauseSession()
     public fun resumeSession(): Boolean
+    public fun leaveBreadcrumb(
+        message: String,
+        metadata: Map<String, Any>? = null,
+        type: BreadcrumbType = BreadcrumbType.MANUAL,
+    )
+
     public fun clearMetadata(section: String)
     public fun clearMetadata(section: String, key: String)
     public fun clearFeatureFlag(name: String)

--- a/bugsnag-kmp/src/jsMain/kotlin/com/bugsnag/kmp/BreadcrumbType.kt
+++ b/bugsnag-kmp/src/jsMain/kotlin/com/bugsnag/kmp/BreadcrumbType.kt
@@ -1,0 +1,12 @@
+package com.bugsnag.kmp
+
+internal fun BreadcrumbType.toPlatformType(): String = when (this) {
+    BreadcrumbType.ERROR -> "error"
+    BreadcrumbType.LOG -> "log"
+    BreadcrumbType.MANUAL -> "manual"
+    BreadcrumbType.NAVIGATION -> "navigation"
+    BreadcrumbType.PROCESS -> "process"
+    BreadcrumbType.REQUEST -> "request"
+    BreadcrumbType.STATE -> "state"
+    BreadcrumbType.USER -> "user"
+}

--- a/bugsnag-kmp/src/jsMain/kotlin/com/bugsnag/kmp/Bugsnag.kt
+++ b/bugsnag-kmp/src/jsMain/kotlin/com/bugsnag/kmp/Bugsnag.kt
@@ -26,6 +26,15 @@ public actual object Bugsnag {
 
     public actual fun resumeSession(): Boolean = JsBugsnag.resumeSession()
 
+    public actual fun leaveBreadcrumb(
+        message: String,
+        metadata: Map<String, Any>?,
+        type: BreadcrumbType,
+    ) {
+        val dynamicMetadata = metadata?.convertToDynamic()
+        JsBugsnag.leaveBreadcrumb(message, dynamicMetadata, type.toPlatformType())
+    }
+
     public actual fun clearMetadata(section: String) {
         JsBugsnag.clearMetadata(section)
     }

--- a/bugsnag-kmp/src/jsMain/kotlin/com/bugsnag/kmp/JsBugsnag.kt
+++ b/bugsnag-kmp/src/jsMain/kotlin/com/bugsnag/kmp/JsBugsnag.kt
@@ -6,6 +6,7 @@ internal external object JsBugsnag {
     var user: JsUser
 
     fun start(apiOrConfig: dynamic)
+    fun leaveBreadcrumb(message: String, metadata: dynamic, type: String)
     fun addFeatureFlag(name: String, variant: String?)
     fun addMetadata(section: String, data: dynamic)
     fun addMetadata(section: String, key: String, value: Any?)


### PR DESCRIPTION
## Goal
Implement the `Bugsnag.leaveBreadcrumb` function

## Design
Introduced a common `BreadcrumbType` enum that can be mapped to the platform types (as they vary too much for a nice `expect` / `actual` relationship).

The `metadata` for breadcrumbs is nullable and is mapped to an empty `Map` on Android (where it is not nullable).