### PR TITLE
Rename __kmp internals to be clearer __bsg internals

### DIFF
--- a/bugsnag-kmp/src/appleMain/kotlin/com/bugsnag/kmp/Bugsnag.kt
+++ b/bugsnag-kmp/src/appleMain/kotlin/com/bugsnag/kmp/Bugsnag.kt
@@ -2,13 +2,13 @@
 
 package com.bugsnag.kmp
 
-import com.bugsnag.cocoa.__KMP_configureCrashReportCallback
+import com.bugsnag.cocoa.__BSG_KMP_configureCrashReportCallback
 import kotlinx.cinterop.ExperimentalForeignApi
 import com.bugsnag.cocoa.Bugsnag as PlatformBugsnag
 
 public actual object Bugsnag {
     public actual fun start(configuration: Configuration) {
-        __KMP_configureCrashReportCallback(configuration.native)
+        __BSG_KMP_configureCrashReportCallback(configuration.native)
 
         PlatformBugsnag.startWithConfiguration(configuration.native)
         installUncaughtExceptionHandler()

--- a/bugsnag-kmp/src/appleMain/kotlin/com/bugsnag/kmp/KotlinExceptionHandler.kt
+++ b/bugsnag-kmp/src/appleMain/kotlin/com/bugsnag/kmp/KotlinExceptionHandler.kt
@@ -2,7 +2,7 @@
 
 package com.bugsnag.kmp
 
-import com.bugsnag.cocoa.__kmp_kotlinCrashed
+import com.bugsnag.cocoa.__bsg_kotlinCrashed
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.convert
@@ -63,7 +63,7 @@ internal fun installUncaughtExceptionHandler() {
     val previousHook = setUnhandledExceptionHook { throwable ->
         // We only handle a single Kotlin crash in order to avoid swizzling issues
         if (unhandledExceptionCrashed.compareAndSet(0, 1)) {
-            __kmp_kotlinCrashed = true
+            __bsg_kotlinCrashed = true
 
             overrideUnhandled()
             PlatformBugsnag.notify(BugsnagNSException(throwable)) { event ->

--- a/bugsnag-kmp/src/appleMain/nativeInterop/cinterop/bugsnag.def
+++ b/bugsnag-kmp/src/appleMain/nativeInterop/cinterop/bugsnag.def
@@ -4,25 +4,25 @@ language = Objective-C
 
 ---
 
-static void (*__kmp_previousCrashReportCallback)(const struct BSG_KSCrashReportWriter *);
-static volatile bool __kmp_kotlinCrashed = false;
+static void (*__bsg_previousCrashReportCallback)(const struct BSG_KSCrashReportWriter *);
+static volatile bool __bsg_kotlinCrashed = false;
 
-static void __KMP_BSG_KSCrashReportWriter(const struct BSG_KSCrashReportWriter *writer) {
-    if (__kmp_kotlinCrashed) {
+static void __BSG_KMP_KSCrashReportWriter(const struct BSG_KSCrashReportWriter *writer) {
+    if (__bsg_kotlinCrashed) {
         writer->beginObject(writer, "bugsnagKotlinMultiplatform");
         writer->addBooleanElement(writer, "kotlinCrashed", true);
         writer->endContainer(writer);
     }
 
-    void (*_previousCrashReportCallback)(const BSG_KSCrashReportWriter *) = __kmp_previousCrashReportCallback;
+    void (*_previousCrashReportCallback)(const BSG_KSCrashReportWriter *) = __bsg_previousCrashReportCallback;
     if (_previousCrashReportCallback != NULL) {
         _previousCrashReportCallback(writer);
     }
 }
 
-static void __KMP_configureCrashReportCallback(BugsnagConfiguration *configuration) {
-    __kmp_previousCrashReportCallback = configuration.onCrashHandler;
-    configuration.onCrashHandler = &__KMP_BSG_KSCrashReportWriter;
+static void __BSG_KMP_configureCrashReportCallback(BugsnagConfiguration *configuration) {
+    __bsg_previousCrashReportCallback = configuration.onCrashHandler;
+    configuration.onCrashHandler = &__BSG_KMP_KSCrashReportWriter;
 
     [configuration addOnSendErrorBlock:^BOOL (BugsnagEvent *event) {
         return [event getMetadataFromSection:@"bugsnagKotlinMultiplatform" withKey:@"kotlinCrashed"] != YES;


### PR DESCRIPTION
## Goal
Clarify the internal nature of the callback & crash helpers on Cocoa.