### PR TITLE
Bugsnag.notify

### DIFF
--- a/bugsnag-kmp/src/androidMain/kotlin/com/bugsnag/kmp/Bugsnag.kt
+++ b/bugsnag-kmp/src/androidMain/kotlin/com/bugsnag/kmp/Bugsnag.kt
@@ -16,6 +16,10 @@ public actual object Bugsnag {
 
     public actual fun isStarted(): Boolean = PlatformBugsnag.isStarted()
 
+    public actual fun notify(error: Throwable) {
+        PlatformBugsnag.notify(error)
+    }
+
     public actual fun leaveBreadcrumb(
         message: String,
         metadata: Map<String, Any>?,

--- a/bugsnag-kmp/src/appleMain/kotlin/com/bugsnag/kmp/Bugsnag.kt
+++ b/bugsnag-kmp/src/appleMain/kotlin/com/bugsnag/kmp/Bugsnag.kt
@@ -22,6 +22,10 @@ public actual object Bugsnag {
 
     public actual fun isStarted(): Boolean = PlatformBugsnag.isStarted()
 
+    public actual fun notify(error: Throwable) {
+        PlatformBugsnag.notify(BugsnagNSException(error))
+    }
+
     public actual fun addMetadata(section: String, key: String, value: Any?) {
         PlatformBugsnag.addMetadata(value, key, section)
     }

--- a/bugsnag-kmp/src/commonMain/kotlin/com/bugsnag/kmp/Bugsnag.kt
+++ b/bugsnag-kmp/src/commonMain/kotlin/com/bugsnag/kmp/Bugsnag.kt
@@ -3,6 +3,7 @@ package com.bugsnag.kmp
 public expect object Bugsnag {
     public fun start(configuration: Configuration)
     public fun isStarted(): Boolean
+    public fun notify(error: Throwable)
     public fun addMetadata(section: String, key: String, value: Any?)
     public fun addMetadata(section: String, data: Map<String, Any>)
     public fun startSession()

--- a/bugsnag-kmp/src/jsMain/kotlin/com/bugsnag/kmp/Bugsnag.kt
+++ b/bugsnag-kmp/src/jsMain/kotlin/com/bugsnag/kmp/Bugsnag.kt
@@ -13,6 +13,10 @@ public actual object Bugsnag {
 
     public actual fun isStarted(): Boolean = JsBugsnag.isStarted()
 
+    public actual fun notify(error: Throwable) {
+        JsBugsnag.notify(error)
+    }
+
     public actual fun addMetadata(section: String, key: String, value: Any?) {
         JsBugsnag.addMetadata(section, key, value)
     }

--- a/bugsnag-kmp/src/jsMain/kotlin/com/bugsnag/kmp/JsBugsnag.kt
+++ b/bugsnag-kmp/src/jsMain/kotlin/com/bugsnag/kmp/JsBugsnag.kt
@@ -6,6 +6,7 @@ internal external object JsBugsnag {
     var user: JsUser
 
     fun start(apiOrConfig: dynamic)
+    fun notify(error: Throwable)
     fun leaveBreadcrumb(message: String, metadata: dynamic, type: String)
     fun addFeatureFlag(name: String, variant: String?)
     fun addMetadata(section: String, data: dynamic)

--- a/features/android/notify.feature
+++ b/features/android/notify.feature
@@ -1,0 +1,25 @@
+Feature: Handled error smoke test
+
+  Scenario: Handled error smoke test
+    When I run "NotifyScenario"
+    Then I wait to receive an error
+    And the exception "errorClass" ends with "Exception"
+    And the exception "message" equals "I expected this"
+    And the event "context" equals "running context"
+    And the event "user.id" equals "xyz321"
+    And the event "user.email" equals "noreply@example.com"
+    And the event "user.name" equals "User McUserface"
+    And the event "app.releaseStage" equals "notify"
+    And the event "metaData.test.scenario" equals "NotifyScenario"
+    And the event "metaData.test.config" equals "configuration"
+    And the event "metaData.test_data.string" equals "a string"
+    And the event "metaData.test_data.number" equals 123
+    And the event "metaData.test_data.boolean" is true
+    And the event "metaData.test_data.array.0" equals "a"
+    And the event "metaData.test_data.array.1" equals "b"
+    And the event "metaData.test_data.array.2" equals "c"
+    And the event "metaData.test_data.map.a" equals "b"
+    And the event "metaData.test_data.map.c" equals "d"
+    And the event "metaData.test.badValue" is null
+    And event 0 contains the feature flag "flag2" with variant "featureFlag2"
+    And event 0 does not contain the feature flag "flag1"

--- a/features/fixtures/mazerunner/app/src/commonMain/kotlin/com/bugsnag/kmp/mazerunner/scenarios/AAllScenarios.kt
+++ b/features/fixtures/mazerunner/app/src/commonMain/kotlin/com/bugsnag/kmp/mazerunner/scenarios/AAllScenarios.kt
@@ -4,4 +4,5 @@ import com.bugsnag.kmp.mazerunner.Scenario
 
 internal val scenarios: List<Scenario> = listOf(
     UnhandledExceptionScenario,
+    NotifyScenario,
 )

--- a/features/fixtures/mazerunner/app/src/commonMain/kotlin/com/bugsnag/kmp/mazerunner/scenarios/NotifyScenario.kt
+++ b/features/fixtures/mazerunner/app/src/commonMain/kotlin/com/bugsnag/kmp/mazerunner/scenarios/NotifyScenario.kt
@@ -1,0 +1,40 @@
+package com.bugsnag.kmp.mazerunner.scenarios
+
+import com.bugsnag.kmp.Bugsnag
+import com.bugsnag.kmp.User
+import com.bugsnag.kmp.mazerunner.Scenario
+
+object NotifyScenario : Scenario("NotifyScenario") {
+    override suspend fun runScenario(config: String) {
+        startBugsnag {
+            addMetadata("test", "scenario", "NotifyScenario")
+            addMetadata("test", "badValue", "I am a bad value")
+            clearMetadata("test", "badValue")
+
+            addMetadata("test", "config", "configuration")
+
+            addFeatureFlag("flag1", "featureFlag")
+            addFeatureFlag("flag2", "featureFlag2")
+            clearFeatureFlag("flag1")
+
+            user = User(id = "xyz321", name = "User McUserface", email = "noreply@example.com")
+            releaseStage = "notify"
+            context = "startup context"
+        }
+
+        Bugsnag.context = "running context"
+
+        Bugsnag.addMetadata(
+            "test_data",
+            mapOf(
+                "string" to "a string",
+                "number" to 123,
+                "boolean" to true,
+                "array" to listOf("a", "b", "c"),
+                "map" to mapOf("a" to "b", "c" to "d"),
+            ),
+        )
+
+        Bugsnag.notify(Exception("I expected this"))
+    }
+}

--- a/features/ios/notify.feature
+++ b/features/ios/notify.feature
@@ -1,0 +1,25 @@
+Feature: Handled error smoke test
+
+  Scenario: Handled error smoke test
+    When I run "NotifyScenario"
+    Then I wait to receive an error
+    And the exception "errorClass" ends with "Exception"
+    And the exception "message" equals "I expected this"
+    And the event "context" equals "running context"
+    And the event "user.id" equals "xyz321"
+    And the event "user.email" equals "noreply@example.com"
+    And the event "user.name" equals "User McUserface"
+    And the event "app.releaseStage" equals "notify"
+    And the event "metaData.test.scenario" equals "NotifyScenario"
+    And the event "metaData.test.config" equals "configuration"
+    And the event "metaData.test_data.string" equals "a string"
+    And the event "metaData.test_data.number" equals 123
+    And the event "metaData.test_data.boolean" equals 1
+    And the event "metaData.test_data.array.0" equals "a"
+    And the event "metaData.test_data.array.1" equals "b"
+    And the event "metaData.test_data.array.2" equals "c"
+    And the event "metaData.test_data.map.a" equals "b"
+    And the event "metaData.test_data.map.c" equals "d"
+    And the event "metaData.test.badValue" is null
+    And event 0 contains the feature flag "flag2" with variant "featureFlag2"
+    And event 0 does not contain the feature flag "flag1"


### PR DESCRIPTION
## Goal
Implement the `Bugsnag.notify` function (without callback support).

## Design
Initially the SDK does not support callbacks, so the `notify` function only accepts a single `Throwable` argument.

## Testing
A new end-to-end test was added