### PR TITLE
Add release stage to CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,7 +7,7 @@ steps:
     key: "fixtures"
     timeout_in_minutes: 30
     agents:
-      queue: macos-14
+      queue: macos-15
     artifact_paths:
       - "build/test-fixture.apk"
       - "build/android_fixture_url.txt"
@@ -26,7 +26,7 @@ steps:
   - label: ':android: Coding standards checks'
     timeout_in_minutes: 20
     agents:
-      queue: macos-14
+      queue: macos-15
     command: './gradlew --continue detekt ktlintCheck'
     env:
       JAVA_VERSION: 17
@@ -34,7 +34,7 @@ steps:
   - label: ':kotlin: :firefox: Browser unit tests'
     timeout_in_minutes: 20
     agents:
-      queue: macos-14
+      queue: macos-15
     command: './gradlew --continue jsBrowserTest'
     env:
       JAVA_VERSION: 17
@@ -42,7 +42,7 @@ steps:
   - label: ':android: Lint mazerunner scenarios'
     timeout_in_minutes: 10
     agents:
-      queue: macos-14
+      queue: macos-15
     commands:
       - make install
       - cd features/fixtures/mazerunner

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -135,3 +135,36 @@ steps:
 #      automatic:
 #        - exit_status: "*"
 #          limit: 1
+
+  # If this is the 'main' branch activate a manual publishing step
+  - block: 'Trigger package publish'
+#    if: build.branch == "main"
+    key: trigger-publish
+    blocked_state: passed
+
+  - label: ':docker: Build KMP base image'
+#    if: build.branch == "main"
+    key: 'kmp-common'
+    timeout_in_minutes: 30
+    depends_on: 'trigger-publish'
+    plugins:
+      - docker-compose#v4.7.0:
+          build:
+            - kmp-common
+          image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/android
+          cache-from:
+            - kmp-common:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:kmp-release
+      - docker-compose#v4.7.0:
+          push:
+            - kmp-common:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:kmp-release
+
+  - label: 'Publish :rocket:'
+#    if: build.branch == "main"
+    depends_on: 'kmp-common'
+    timeout_in_minutes: 30
+    env:
+      BUILDKITE_PLUGIN_S3_SECRETS_BUCKET_PREFIX: bugsnag-android-publish
+    plugins:
+      docker-compose#v4.7.0:
+        no-cache: true
+        run: kmp-publisher

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -138,12 +138,12 @@ steps:
 
   # If this is the 'main' branch activate a manual publishing step
   - block: 'Trigger package publish'
-#    if: build.branch == "main"
+    if: build.branch == "main"
     key: trigger-publish
     blocked_state: passed
 
   - label: ':docker: Build KMP base image'
-#    if: build.branch == "main"
+    if: build.branch == "main"
     key: 'kmp-common'
     timeout_in_minutes: 30
     depends_on: 'trigger-publish'
@@ -159,7 +159,7 @@ steps:
             - kmp-common:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:kmp-release
 
   - label: 'Publish :rocket:'
-#    if: build.branch == "main"
+    if: build.branch == "main"
     depends_on: 'kmp-common'
     timeout_in_minutes: 30
     env:

--- a/bugsnag-kmp/build.gradle.kts
+++ b/bugsnag-kmp/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
@@ -9,6 +10,9 @@ plugins {
     alias(libs.plugins.detekt)
     alias(libs.plugins.ktlint)
 }
+
+version = "${project.properties["VERSION_NAME"]}"
+group = "${project.properties["GROUP"]}"
 
 kotlin {
     compilerOptions {
@@ -115,5 +119,37 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+    }
+}
+
+mavenPublishing {
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    signAllPublications()
+
+    pom {
+        name = "Bugsnag KMP"
+        description = "Kotlin Multiplatform library for Bugsnag crash reporting"
+        inceptionYear = "2025"
+        url = "https://github.com/bugsnag/bugsnag-kmp"
+        licenses {
+            license {
+                name = "The MIT License"
+                url = "https://opensource.org/licenses/MIT"
+                distribution = "repo"
+            }
+        }
+        developers {
+            developer {
+                id = "bugsnag"
+                name = "Bugsnag Team"
+                email = "support@bugsnag.com"
+            }
+        }
+        scm {
+            url = "https://github.com/bugsnag/bugsnag-kotlin-multiplatform"
+            connection = "scm:git:git://github.com/bugsnag/bugsnag-kotlin-multiplatform.git"
+            developerConnection = "scm:git:ssh://git@github.com/bugsnag/bugsnag-kotlin-multiplatform.git"
+        }
     }
 }

--- a/bugsnag-kmp/build.gradle.kts
+++ b/bugsnag-kmp/build.gradle.kts
@@ -6,7 +6,7 @@ import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
-    id("com.vanniktech.maven.publish") version "0.32.0"
+    alias(libs.plugins.vanniktech.mavenPublish)
     alias(libs.plugins.detekt)
     alias(libs.plugins.ktlint)
 }

--- a/bugsnag-kmp/build.gradle.kts
+++ b/bugsnag-kmp/build.gradle.kts
@@ -6,7 +6,7 @@ import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.vanniktech.mavenPublish)
+    id("com.vanniktech.maven.publish") version "0.32.0"
     alias(libs.plugins.detekt)
     alias(libs.plugins.ktlint)
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,22 @@ services:
       - ./reports/:/app/reports/
       - /var/run/docker.sock:/var/run/docker.sock
 
+  kmp-common:
+    build:
+      context: .
+      dockerfile: dockerfiles/Dockerfile.kmp-common
+
+  kmp-publisher:
+    build:
+      context: .
+      dockerfile: dockerfiles/Dockerfile.kmp-publisher
+    environment:
+      KEY:
+      KEY_ID:
+      KEY_PASS:
+      PUBLISH_USER:
+      PUBLISH_PASS:
+
 networks:
   default:
     name: ${BUILDKITE_JOB_ID:-android-maze-runner}

--- a/dockerfiles/Dockerfile.kmp-common
+++ b/dockerfiles/Dockerfile.kmp-common
@@ -1,0 +1,28 @@
+FROM ubuntu:24.04@sha256:99c35190e22d294cdace2783ac55effc69d32896daaa265f0bbedbcde4fbe3e5
+
+RUN apt-get update > /dev/null
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y wget maven gnupg1 cppcheck libncurses6 jq clang-format unzip curl git
+RUN apt-get clean > /dev/null
+
+ENV ANDROID_SDK_ROOT="/sdk"
+ENV ANDROID_CMDLINE_TOOLS="${ANDROID_SDK_ROOT}/cmdline-tools/latest"
+ENV PATH="${PATH}:${ANDROID_CMDLINE_TOOLS}/bin"
+ENV CMDLINE_TOOLS_NAME="commandlinetools-linux-6858069_latest.zip"
+WORKDIR $ANDROID_SDK_ROOT
+
+RUN mkdir ~/.gradle
+
+# Download Android command line tools
+RUN wget https://dl.google.com/android/repository/${CMDLINE_TOOLS_NAME} -q
+RUN mkdir cmdline-tools
+RUN unzip -q ${CMDLINE_TOOLS_NAME} -d /sdk/cmdline-tools
+RUN mv /sdk/cmdline-tools/cmdline-tools $ANDROID_CMDLINE_TOOLS
+RUN rm $CMDLINE_TOOLS_NAME
+
+# Install Android tools using sdkmanager
+RUN yes | sdkmanager "platform-tools" > /dev/null
+RUN yes | sdkmanager "platforms;android-34" > /dev/null
+
+# Install bundletool
+RUN wget -q https://github.com/google/bundletool/releases/download/1.4.0/bundletool-all-1.4.0.jar
+RUN mv bundletool-all-1.4.0.jar bundletool.jar

--- a/dockerfiles/Dockerfile.kmp-publisher
+++ b/dockerfiles/Dockerfile.kmp-publisher
@@ -1,0 +1,15 @@
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/android:kmp-release as kmp
+
+WORKDIR /app
+
+# Copy gradle files
+COPY gradlew gradle.properties /app/
+COPY gradle/ /app/gradle/
+COPY build.gradle.kts settings.gradle.kts /app/
+
+# Copy sdk source files
+COPY bugsnag-kmp/ bugsnag-kmp/
+COPY scripts/ scripts/
+COPY LICENSE LICENSE
+
+CMD "scripts/docker-publish.sh"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,5 +25,5 @@ kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref =
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
-vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.29.0" }
+vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.32.0" }
 native-cocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }

--- a/scripts/docker-publish.sh
+++ b/scripts/docker-publish.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# === Variables ===
+GRADLE_DIR="$HOME/.gradle"
+KEY_FILE="$HOME/temp_key"
+KEY_RING="/publishKey.gpg"
+GRADLE_PROPERTIES="$GRADLE_DIR/gradle.properties"
+
+# === GPG Key Setup ===
+echo "$KEY" > "$KEY_FILE"
+base64 --decode "$KEY_FILE" > "$KEY_RING"
+
+# === Gradle Configuration ===
+mkdir -p "$GRADLE_DIR"
+{
+  echo "signing.keyId=$KEY_ID"
+  echo "signing.password=$KEY_PASS"
+  echo "signing.secretKeyRingFile=$KEY_RING"
+  echo "NEXUS_USERNAME=$PUBLISH_USER"
+  echo "NEXUS_PASSWORD=$PUBLISH_PASS"
+  echo "nexusUsername=$PUBLISH_USER"
+  echo "nexusPassword=$PUBLISH_PASS"
+  echo "mavenCentralUsername=$PUBLISH_USER"
+  echo "mavenCentralPassword=$PUBLISH_PASS"
+} >> "$GRADLE_PROPERTIES"
+
+# === Build and Publish ===
+/app/gradlew assembleRelease publish --no-daemon --max-workers=1
+
+# === Close Staging Repository ===
+echo "--- Closing staging repository"
+echo "Fetching staging repositories..."
+
+REPOS_JSON=$(curl -s -u "$PUBLISH_USER:$PUBLISH_PASS" \
+  "https://ossrh-staging-api.central.sonatype.com/manual/search/repositories")
+
+if [[ -z "$REPOS_JSON" ]]; then
+  echo "Failed to retrieve repository list. Check your credentials or network." >&2
+  exit 1
+fi
+
+REPO_KEYS=($(echo "$REPOS_JSON" | jq -r '.repositories[] | select(.state == "open") | .key'))
+
+if [[ "${#REPO_KEYS[@]}" -eq 0 ]]; then
+  echo "No open repositories found."
+  exit 1
+elif [[ "${#REPO_KEYS[@]}" -gt 1 ]]; then
+  echo "Multiple open repositories found. Please specify which one to close:"
+  printf '%s\n' "${REPO_KEYS[@]}"
+  exit 1
+fi
+
+REPO_KEY="${REPO_KEYS[0]}"
+echo "Closing repository $REPO_KEY..."
+
+URL="https://ossrh-staging-api.central.sonatype.com/manual/upload/repository/$REPO_KEY?publishing_type=user_managed"
+RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST -u "$PUBLISH_USER:$PUBLISH_PASS" "$URL")
+
+BODY=$(echo "$RESPONSE" | sed -n '/^HTTP_STATUS:/!p')
+STATUS=$(echo "$RESPONSE" | sed -n 's/^HTTP_STATUS://p')
+
+if [[ "$STATUS" != "200" ]]; then
+  echo "Failed to close repository. HTTP Status: $STATUS"
+  echo "$BODY" | jq -r
+  exit 1
+fi
+
+echo "Repository $REPO_KEY closed successfully."
+
+echo "Go to https://oss.sonatype.org/ to release the final artefact."

--- a/scripts/docker-publish.sh
+++ b/scripts/docker-publish.sh
@@ -26,47 +26,7 @@ mkdir -p "$GRADLE_DIR"
   echo "mavenCentralPassword=$PUBLISH_PASS"
 } >> "$GRADLE_PROPERTIES"
 
-# === Build and Publish ===
+# === Build, Publish and Close===
 /app/gradlew assembleRelease publish --no-daemon --max-workers=1
-
-# === Close Staging Repository ===
-echo "--- Closing staging repository"
-echo "Fetching staging repositories..."
-
-REPOS_JSON=$(curl -s -u "$PUBLISH_USER:$PUBLISH_PASS" \
-  "https://ossrh-staging-api.central.sonatype.com/manual/search/repositories")
-
-if [[ -z "$REPOS_JSON" ]]; then
-  echo "Failed to retrieve repository list. Check your credentials or network." >&2
-  exit 1
-fi
-
-REPO_KEYS=($(echo "$REPOS_JSON" | jq -r '.repositories[] | select(.state == "open") | .key'))
-
-if [[ "${#REPO_KEYS[@]}" -eq 0 ]]; then
-  echo "No open repositories found."
-  exit 1
-elif [[ "${#REPO_KEYS[@]}" -gt 1 ]]; then
-  echo "Multiple open repositories found. Please specify which one to close:"
-  printf '%s\n' "${REPO_KEYS[@]}"
-  exit 1
-fi
-
-REPO_KEY="${REPO_KEYS[0]}"
-echo "Closing repository $REPO_KEY..."
-
-URL="https://ossrh-staging-api.central.sonatype.com/manual/upload/repository/$REPO_KEY?publishing_type=user_managed"
-RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST -u "$PUBLISH_USER:$PUBLISH_PASS" "$URL")
-
-BODY=$(echo "$RESPONSE" | sed -n '/^HTTP_STATUS:/!p')
-STATUS=$(echo "$RESPONSE" | sed -n 's/^HTTP_STATUS://p')
-
-if [[ "$STATUS" != "200" ]]; then
-  echo "Failed to close repository. HTTP Status: $STATUS"
-  echo "$BODY" | jq -r
-  exit 1
-fi
-
-echo "Repository $REPO_KEY closed successfully."
 
 echo "Go to https://oss.sonatype.org/ to release the final artefact."


### PR DESCRIPTION
## Goal

Configure the Gradle Maven Publish Plugin to publish to Maven Central when a change is pushed to the main branch. This is using the `vanniktech.maven.publish` plugin. 

Move the CI steps from using the `macos-14` queue to use the `macos-15` queue

## Testing

Tested [here](https://buildkite.com/bugsnag/bugsnag-kotlin-multiplatform/builds/438/steps/canvas?sid=0197794f-eb14-434d-a69a-aa017b7d6be1) and I have validated that the staging repo in Maven Central has been created and closed.