### PR TITLE
Fix incomplete iOS crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## TBD
 
 - Correctly force-terminate Cocoa apps that fatally crash to ensure the app does not appear to become unresponsive
-  []()
+  [#50](https://github.com/bugsnag/bugsnag-kotlin-multiplatform/pull/50)
 
 ## [1.0.0-beta04] - 2025-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+- Correctly force-terminate Cocoa apps that fatally crash to ensure the app does not appear to become unresponsive
+  []()
+
 ## [1.0.0-beta04] - 2025-07-30
 
 - Add support for `OnErrorCallback` callbacks in `Bugsnag.notify` along with initial support for the `Event` model

--- a/bugsnag-kmp/src/appleMain/kotlin/com/bugsnag/kmp/Bugsnag.kt
+++ b/bugsnag-kmp/src/appleMain/kotlin/com/bugsnag/kmp/Bugsnag.kt
@@ -8,10 +8,15 @@ import com.bugsnag.cocoa.Bugsnag as PlatformBugsnag
 
 public actual object Bugsnag {
     public actual fun start(configuration: Configuration) {
-        __BSG_KMP_configureCrashReportCallback(configuration.native)
+        val unhandledExceptions = configuration.native.enabledErrorTypes.unhandledExceptions
+        if (unhandledExceptions) {
+            __BSG_KMP_configureCrashReportCallback(configuration.native)
+        }
 
         PlatformBugsnag.startWithConfiguration(configuration.native)
-        installUncaughtExceptionHandler()
+        if (unhandledExceptions) {
+            installUncaughtExceptionHandler()
+        }
     }
 
     public inline fun start(configure: Configuration.() -> Unit) {

--- a/bugsnag-kmp/src/appleMain/kotlin/com/bugsnag/kmp/KotlinExceptionHandler.kt
+++ b/bugsnag-kmp/src/appleMain/kotlin/com/bugsnag/kmp/KotlinExceptionHandler.kt
@@ -2,6 +2,7 @@
 
 package com.bugsnag.kmp
 
+import com.bugsnag.cocoa.BSGSeverity
 import com.bugsnag.cocoa.__bsg_kotlinCrashed
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -15,6 +16,7 @@ import platform.objc.class_getInstanceMethod
 import platform.objc.method_getImplementation
 import platform.objc.method_setImplementation
 import kotlin.concurrent.AtomicInt
+import kotlin.concurrent.AtomicReference
 import kotlin.experimental.ExperimentalNativeApi
 import com.bugsnag.cocoa.Bugsnag as PlatformBugsnag
 
@@ -43,7 +45,8 @@ internal class BugsnagNSException(
 private fun overrideUnhandled() {
     // This function is a work-around and will be removed in a future release, once we have a
     // mechanism to affect the delivery strategy directly
-    val handledState = NSClassFromString("BugsnagHandledState") ?: return
+    val handledState = NSClassFromString("BugsnagHandledState")
+        ?: return
     val originalUnhandledSelector = NSSelectorFromString("originalUnhandledValue")
         ?: return
     val unhandledSelector = NSSelectorFromString("unhandled")
@@ -59,21 +62,22 @@ private fun overrideUnhandled() {
 @OptIn(ExperimentalNativeApi::class)
 internal fun installUncaughtExceptionHandler() {
     val unhandledExceptionCrashed = AtomicInt(0)
-    var previousHookRef: ReportUnhandledExceptionHook? = null
-    val previousHook = setUnhandledExceptionHook { throwable ->
-        // We only handle a single Kotlin crash in order to avoid swizzling issues
+    val previousHookRef = AtomicReference<ReportUnhandledExceptionHook?>(null)
+    previousHookRef.value = setUnhandledExceptionHook { throwable ->
+        // We only handle a single Kotlin crash
         if (unhandledExceptionCrashed.compareAndSet(0, 1)) {
             __bsg_kotlinCrashed = true
 
             overrideUnhandled()
             PlatformBugsnag.notify(BugsnagNSException(throwable)) { event ->
                 if (event == null) return@notify true
-                event.setUnhandled(true)
+                event.severity = BSGSeverity.BSGSeverityError
+                event.unhandled = true
                 true
             }
         }
 
-        previousHookRef?.invoke(throwable)
+        previousHookRef.value?.invoke(throwable)
+        terminateWithUnhandledException(throwable)
     }
-    previousHookRef = previousHook
 }

--- a/bugsnag-kmp/src/appleMain/nativeInterop/cinterop/bugsnag.def
+++ b/bugsnag-kmp/src/appleMain/nativeInterop/cinterop/bugsnag.def
@@ -25,6 +25,6 @@ static void __BSG_KMP_configureCrashReportCallback(BugsnagConfiguration *configu
     configuration.onCrashHandler = &__BSG_KMP_KSCrashReportWriter;
 
     [configuration addOnSendErrorBlock:^BOOL (BugsnagEvent *event) {
-        return [event getMetadataFromSection:@"bugsnagKotlinMultiplatform" withKey:@"kotlinCrashed"] != YES;
+        return [event getMetadataFromSection:@"bugsnagKotlinMultiplatform" withKey:@"kotlinCrashed"] == nil;
     }];
 }

--- a/example/BugsnagExample/settings.gradle.kts
+++ b/example/BugsnagExample/settings.gradle.kts
@@ -17,6 +17,7 @@ pluginManagement {
 
 dependencyResolutionManagement {
     repositories {
+        mavenLocal()
         google {
             mavenContent {
                 includeGroupAndSubgroups("androidx")


### PR DESCRIPTION
## Goal
The iOS `UnhandledExceptionHook` should call `terminateWithUnhandledException` once any other hooks have returned in order to crash the app as expected.

## Changeset

- the `UnhandledExceptionHook` installed on iOS now calls `terminateWithUnhandledException` after other hooks have returned (if they return)
- setting `enabledErrorTypes.unhandledExceptions = false` will stop the Kotlin `UnhandledExceptionHook` being installed on iOS
- correctly stop the cocoa notifier double-reporting Kotlin crashes

## Testing
Manually tested