### PR TITLE
v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBD
+## [1.0.0] - (2025-09-23)
 
 - Correctly force-terminate Cocoa apps that fatally crash to ensure the app does not appear to become unresponsive
   [#50](https://github.com/bugsnag/bugsnag-kotlin-multiplatform/pull/50)

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,5 @@ ifneq ($(VERSION),)
 	@echo "Bumping version to $(VERSION)"
 	@./scripts/bump-version.sh $(VERSION)
 else
-	@echo "Please provide a version number"
 	@./scripts/bump-version.sh
 endif

--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@
 
 Detect crashes in your applications using Kotlin Multiplatform: collecting diagnostic information and immediately notifying your development team, helping you to understand and resolve issues as fast as possible.
 
-## Beta SDK
-
-This SDK is still in beta but builds upon on our existing [bugsnag-android](https://github.com/bugsnag/bugsnag-android/), [bugsnag-cocoa](https://github.com/bugsnag/bugsnag-cocoa) and [bugsnag-js](https://github.com/bugsnag/bugsnag-js) SDKs. As such it can be considered stable and safe for use in production, but possibly missing features in the Kotlin common layer that are available in the platform-specific SDKs. We are working to add more features to the common layer, but if you need a specific feature, please [open an issue](https://github.com/bugsnag/bugsnag-kotlin-multiplatform/issues/new?template=feature_request.md).
-
 ## Installation
 
 Add `bugsnag-kmp` to your `build.gradle.kts` file:

--- a/features/android/event.feature
+++ b/features/android/event.feature
@@ -17,11 +17,11 @@ Feature: Handled event smoke test
 
     # Device data
     And the event "device.jailbroken" is false
-    And the event "device.locale" equals "en_US"
-    And the event "device.manufacturer" equals "Google"
-    And the event "device.model" equals "Pixel 8"
+    And the event "device.locale" is not null
+    And the event "device.manufacturer" is not null
+    And the event "device.model" is not null
     And the event "device.osName" equals "android"
-    And the event "device.osVersion" equals "14"
+    And the event "device.osVersion" is not null
     And the event "device.runtimeVersions" is not null
     And the event "device.totalMemory" is greater than 0
 

--- a/features/ios/event.feature
+++ b/features/ios/event.feature
@@ -17,11 +17,11 @@ Feature: Handled event smoke test
 
     # Device data
     And the event "device.jailbroken" is false
-    And the event "device.locale" equals "en_US"
+    And the event "device.locale" is not null
     And the event "device.manufacturer" equals "Apple"
-    And the event "device.model" equals "iPhone15,2"
+    And the event "device.model" is not null
     And the event "device.osName" equals "iOS"
-    And the event "device.osVersion" equals "16.1"
+    And the event "device.osVersion" is not null
     And the event "device.runtimeVersions" is not null
     And the event "device.totalMemory" is greater than 0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.bugsnag
-VERSION_NAME=1.0.0-beta04
+VERSION_NAME=1.0.0
 
 #Kotlin
 kotlin.code.style=official

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -20,4 +20,4 @@ fi
 
 echo Bumping the version number to $VERSION
 sed -i '' "s/VERSION_NAME=.*/VERSION_NAME=$VERSION/" gradle.properties
-sed -i '' "s/## [Unreleased]/## [$VERSION] - ($(date '+%Y-%m-%d'))/" CHANGELOG.md
+sed -i '' "s/## Unreleased/## [$VERSION] - ($(date '+%Y-%m-%d'))/" CHANGELOG.md


### PR DESCRIPTION
- Correctly force-terminate Cocoa apps that fatally crash to ensure the app does not appear to become unresponsive
  [#50](https://github.com/bugsnag/bugsnag-kotlin-multiplatform/pull/50)
